### PR TITLE
Update README with Getting Started section referencing node-elm-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Elm-Test [![Build Status](https://travis-ci.org/deadfoxygrandpa/Elm-Test.png?bra
 
 A unit testing framework for Elm
 
+## Getting Started
+
+The simplest way to get started with Elm Test is to install & run it via [node-elm-test](https://github.com/rtfeldman/node-elm-test). This package can install Elm Test and its dependencies for you, as well as providing you with a command line test runner and an example test suite.
+
 ## Creating Tests
 
 Creating a test case is very simple. You only need a name and an assertion:


### PR DESCRIPTION
This change adds a small Getting Started section to the beginning of
the README, directing users to node-elm-test.

The rationale behind this is that node-elm-test is currently
the quickest & most straightforward way to get started with Elm Test,
and yet it isn't readily discoverable from the Elm Test repo. I think
that a number of the problems and questions raised in Github Issues
and in the elm-discuss mailing list could be pre-empted by this.

We should direct folks to node-elm-test immediately so they have a
hassle-free initial experience getting Elm Test set up.