### PR TITLE
Add pass and fail assertions.

### DIFF
--- a/src/ElmTest.elm
+++ b/src/ElmTest.elm
@@ -1,6 +1,6 @@
 module ElmTest
     ( Test, test, defaultTest, equals, suite
-    , Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList
+    , Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList, pass, fail
     , elementRunner, consoleRunner, stringRunner
     ) where
 
@@ -10,7 +10,7 @@ module ElmTest
 @docs Test, test, defaultTest, equals, suite
 
 # Assertions
-@docs Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList
+@docs Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList, pass, fail
 
 # Running Tests
 @docs elementRunner, consoleRunner, stringRunner
@@ -99,6 +99,22 @@ list of assertions that these values are equal. -}
 assertionList : List a -> List a -> List Assertion
 assertionList =
     ElmTest.Assertion.assertionList
+
+
+{-| An assertion that always passes. This is useful when you have test results
+from another library but want to use ElmTest runners.
+-}
+pass : Assertion
+pass =
+    ElmTest.Assertion.AlwaysPass
+
+
+{-| Create an assertion that always fails, for reasons described by the given
+string.
+-}
+fail : String -> Assertion
+fail =
+    ElmTest.Assertion.AlwaysFail
 
 
 {-| Run a test or a test suite and return an `Element` containing the

--- a/src/ElmTest/Assertion.elm
+++ b/src/ElmTest/Assertion.elm
@@ -17,6 +17,8 @@ type Assertion
     | AssertFalse (() -> Bool)
     | AssertEqual (() -> Bool) String String
     | AssertNotEqual (() -> Bool) String String
+    | AlwaysPass
+    | AlwaysFail String
 
 
 {-| Basic function to create an Assert True assertion. Delays execution until tests are run. -}

--- a/src/ElmTest/Run.elm
+++ b/src/ElmTest/Run.elm
@@ -46,24 +46,22 @@ run test =
       in
         case assertion of
           AssertEqual t a b ->
-            runAssertion t
-              <| "Expected: "
-              ++ a
-              ++ "; got: "
-              ++ b
+            runAssertion t <| "Expected: " ++ a ++ "; got: " ++ b
 
           AssertNotEqual t a b ->
-            runAssertion t
-              <| a
-              ++ " equals "
-              ++ b
+            runAssertion t <| a ++ " equals " ++ b
 
           AssertTrue t ->
-            runAssertion t
-              <| "not True"
+            runAssertion t "not True"
 
           AssertFalse t ->
-            runAssertion t <| "not False"
+            runAssertion t "not False"
+
+          AlwaysPass ->
+            runAssertion (always True) ""
+
+          AlwaysFail s ->
+            runAssertion (always False) s
 
     Suite name tests ->
       let

--- a/src/ElmTest/Runner/Element.elm
+++ b/src/ElmTest/Runner/Element.elm
@@ -16,7 +16,7 @@ import Text
 
 import ElmTest.Run as Run
 import ElmTest.Test exposing (..)
-import ElmTest.Runner.String as String
+import ElmTest.Runner.String as StringRunner
 
 
 plainText : String -> Element
@@ -68,7 +68,7 @@ maxOrZero l =
 {-| Runs a list of tests and renders the results as an Element -}
 runDisplay : Test -> Element
 runDisplay tests =
-    case String.run tests of
+    case StringRunner.run tests of
         (summary, allPassed) :: results ->
             let
                 results' =

--- a/src/ElmTest/Test.elm
+++ b/src/ElmTest/Test.elm
@@ -84,6 +84,12 @@ defaultTest a =
 
                 AssertNotEqual _ a b ->
                     a ++ " /= " ++ b
+
+                AlwaysPass ->
+                  "Always passes"
+
+                AlwaysFail s ->
+                  "Always fails"
     in
         test name a
 


### PR DESCRIPTION
These allow elm-check to rely on elm-test's runners, by converting the results of property-based checks to passing or failing. This means less duplicated work writing runners, and allows for property-based and unit testing to be used easily in the same test suite.

Previously, I had written a function to take the output of elm-check and turn it into tests, by `assert True` and `assert False`. This "worked", in that you could read the output, but it was cluttered with extra information on the ends of the lines:

![screen shot 2016-02-05 at 11 40 44 am](https://cloud.githubusercontent.com/assets/1191970/12852707/5c92b392-cbfe-11e5-9bd9-3accb0d6c7dc.png)

With these new functions, and a bit of cleverness in the elm-check to elm-test conversion function, tests now look like this:

![screen shot 2016-02-05 at 11 40 55 am](https://cloud.githubusercontent.com/assets/1191970/12852728/79de370a-cbfe-11e5-98c4-4390606dd4d0.png)

I'd like to go further and add "passed n checks" on the end, but that's more invasive, so I'll start with this.

This branch is based on `taskrunner` since I see that's where recent development is. Also, +1 for dropping 0.15 support in `elm-package.json`. I also cleaned up a few things I came across exploring the codebase. Releasing these changes will be a minor version bump.