### PR TITLE
Add test runner that outputs TAP13 format

### DIFF
--- a/src/ElmTest.elm
+++ b/src/ElmTest.elm
@@ -1,4 +1,4 @@
-module ElmTest (Test, test, defaultTest, equals, suite, Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList, pass, fail, elementRunner, consoleRunner, stringRunner) where
+module ElmTest (Test, test, defaultTest, equals, suite, Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList, pass, fail, elementRunner, consoleRunner, stringRunner, tapRunner) where
 
 {-| A unit testing framework for Elm.
 
@@ -9,7 +9,7 @@ module ElmTest (Test, test, defaultTest, equals, suite, Assertion, assert, asser
 @docs Assertion, assert, assertEqual, assertNotEqual, lazyAssert, assertionList, pass, fail
 
 # Running Tests
-@docs elementRunner, consoleRunner, stringRunner
+@docs elementRunner, consoleRunner, stringRunner, tapRunner
 
 -}
 
@@ -21,6 +21,7 @@ import ElmTest.Run
 import ElmTest.Runner.String
 import ElmTest.Runner.Element
 import ElmTest.Runner.Console
+import ElmTest.Runner.Tap
 
 
 {-| The basic unit of testability.
@@ -147,3 +148,12 @@ probably use either `elementRunner` or `consoleRunner`.
 stringRunner : Test -> String
 stringRunner =
   ElmTest.Runner.String.runDisplay
+
+
+{-| Run a test or a test suite with `laszlopandy/elm-console` and return an
+`IO ()` action which outputs the TAP13 formatted test results to console.
+-}
+tapRunner : Test -> IO ()
+tapRunner =
+  ElmTest.Runner.Tap.runDisplay
+

--- a/src/ElmTest/Runner/Tap.elm
+++ b/src/ElmTest/Runner/Tap.elm
@@ -1,0 +1,98 @@
+module ElmTest.Runner.Tap (runDisplay) where
+
+{-| Run a test suite and display it in TAP13 format.
+
+# Run
+@docs runDisplay
+
+-}
+
+import String
+import Console exposing (..)
+import ElmTest.Run as Run
+import ElmTest.Test exposing (..)
+
+
+version : String
+version =
+  "TAP version 13"
+
+
+plan : Int -> String
+plan n =
+  if n > 0 then
+    "1.." ++ (toString n)
+  else
+    ""
+
+
+indent : String -> String
+indent str =
+  String.join "\n"
+    <| List.map (String.append " ")
+    <| String.lines str
+
+
+testLine : Int -> Run.Result -> String
+testLine n result =
+  let
+    testNumber =
+      toString (n + 1)
+  in
+    case result of
+      Run.Pass description ->
+        "ok " ++ testNumber ++ " - " ++ description
+
+      Run.Fail description err ->
+        "not ok " ++ testNumber ++ " - " ++ description ++
+        "\n ---\n message:" ++ (indent ("\"" ++ err)) ++ "\"\n ..."
+
+      _ ->
+        testLines result
+
+
+testLines : Run.Result -> String
+testLines result =
+  case result of
+    Run.Report description {results} ->
+      String.append ("#\n# " ++ description ++ "\n#\n")
+        <| String.join "\n"
+        <| List.indexedMap testLine results
+
+    _ ->
+      Debug.crash "should never happen"
+
+
+{-| Run a list of tests in the IO type from [Max New's Elm IO library](https://github.com/maxsnew/IO/).
+Requires this library to work. Results are printed to console once all tests have completed. Exits with
+exit code 0 if all tests pass, or with code 1 if any tests fail.
+-}
+runDisplay : Test -> IO ()
+runDisplay t =
+  let
+    n =
+      numberOfTests t
+
+    plan' =
+      plan n
+
+    result =
+      Run.run t
+
+    testLines' =
+      testLines result
+
+    strs =
+      [ version
+      , plan'
+      , testLines'
+      ]
+
+    failed =
+      (Run.failedTests result) /= 0
+  in
+    putStrLn (String.join "\n" strs)
+      >>> if failed then
+            exit 1
+          else
+            exit 0


### PR DESCRIPTION
Hey,

this PR adds a console runner that outputs TAP13 formatted test results (https://testanything.org/tap-version-13-specification.html).

Might help with #34 

Here's a sample 
![sample_tap_output](https://cloud.githubusercontent.com/assets/13130664/13549258/1e2eaa28-e302-11e5-85be-2c6aaa64916d.png)

If there is anything that I can do to get that merged I will be happy to help.
