### PR TITLE
Updates README to reference new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ elm-test [![Build Status](https://travis-ci.org/deadfoxygrandpa/elm-test.png?bra
 
 A unit testing framework for Elm
 
+##  DEPRECATED - Moved to [https://github.com/elm-community/elm-test](https://github.com/elm-community/elm-test)
+
 ## Getting Started
 
 The simplest way to get started with Elm Test is to install & run it via [node-elm-test](https://github.com/rtfeldman/node-elm-test). This package can install Elm Test and its dependencies for you, as well as providing you with a command line test runner and an example test suite.


### PR DESCRIPTION
This is the only link I find when searching for elm-test in Google. It's very difficult for other people to see/understand that this package has been moved to the elm-community. I'm not sure if this also needs to exists, but I'v created a "deprecated" text with a link to the new location. If it is not possible to have the DEPRECATED text, could you please provide a link in the readme to the updated solution?
